### PR TITLE
fix(packages/components/button): fix default background color

### DIFF
--- a/packages/components/src/components/button/ArcButton.ts
+++ b/packages/components/src/components/button/ArcButton.ts
@@ -42,7 +42,7 @@ export default class ArcButton extends LitElement {
 
   /** Set the color of the button. */
   @property({ type: String, reflect: true }) color: ThemeColor =
-    THEME_COLORS.primary;
+    THEME_COLORS.default;
 
   /** Set the size of the button. */
   @property({ type: String, reflect: true }) size: InputSize =

--- a/packages/components/src/components/button/arc-button.styles.ts
+++ b/packages/components/src/components/button/arc-button.styles.ts
@@ -11,7 +11,7 @@ export default [
       cursor: pointer;
       --min-width: 0;
       --btn-color: rgb(var(--arc-input-color));
-      --btn-background: initial;
+      --btn-background: rgb(var(--arc-color-default));
     }
 
     :host([type='tab']) {
@@ -78,7 +78,6 @@ export default [
 
     /* Colors */
     .button--filled.button--default {
-      --btn-background: rgb(var(--arc-color-default));
       --focus-color: rgba(var(--arc-input-color), 0.4);
     }
 

--- a/packages/components/src/components/button/arc-button.test.ts
+++ b/packages/components/src/components/button/arc-button.test.ts
@@ -23,7 +23,7 @@ describe('ArcButton', () => {
     /* Test default properties that reflect to the DOM */
     it('renders the button with default properties in the dom', () => {
       expect(element).dom.to.equal(
-        `<arc-button type='${BUTTON_TYPES.filled}' color='${THEME_COLORS.primary}' size='${INPUT_SIZES.medium}'>Test</arc-button>`,
+        `<arc-button type='${BUTTON_TYPES.filled}' color='${THEME_COLORS.default}' size='${INPUT_SIZES.medium}'>Test</arc-button>`,
       );
     });
 


### PR DESCRIPTION
The default value of the `--btn-background` CSS variable is now `rgb(var(--arc-color-default))` instead of `inital` and the `.button--filled.button--default` CCS selector now does not apply a value to the `background-color` property. This allows the button to be set by the `--btn-background` CSS variable by default by default.

BREAKING CHANGE: To enable this change the `ArcButton.color` default property value has been changed from `primary` to `default`. This is a breaking change for anyone using the `ArcButton` component with the `color` property not set.

fixes: #173 
ARC-8