### PR TITLE
feat(accessibility): add slot to allow for extra options controls

### DIFF
--- a/src/components/accessibility/ArcAccessibility.ts
+++ b/src/components/accessibility/ArcAccessibility.ts
@@ -254,6 +254,7 @@ export default class ArcAccessibility extends LitElement {
                 </div>
               `
             )}
+            <slot name="options"></slot>
           </div>
           <arc-button type="tab" slot="footer" @click=${this.restoreRootDefaults}>Restore defaults</arc-button>
         </arc-drawer>

--- a/src/components/container/ArcContainer.ts
+++ b/src/components/container/ArcContainer.ts
@@ -98,10 +98,14 @@ export default class ArcContainer extends LitElement {
             <slot></slot>
           </div>
         </div>
-        <arc-accessibility
-          id="accessibility"
-          @arc-accessibility-change=${this.handleAccessibilityChange}
-        ></arc-accessibility>
+        <slot
+          name="accessibility"
+          @arc-accessibility-change=${this.handleAccessibilityChange}>
+            <arc-accessibility
+            id="accessibility"
+            @arc-accessibility-change=${this.handleAccessibilityChange}>
+            </arc-accessibility>
+        </slot>
         <slot name="bottom">
           <arc-bottombar>
             <arc-icon-button name=${ICON_TYPES.home} href="/" label="Return home">Home</arc-icon-button>


### PR DESCRIPTION
This adds a slot with the name of options to the `ArcAccessibility` component. This allows for the addition of extra controls to be added to the accessibility component.

It is required to listen to the `arc-show-accessibility` event on the `ArcNavbar` component and call `ArcAccessibility.show()` to show the accessibility component.

It is also required to implement all the functionality for the extra controls placed within the slot. Only the default controls are implemented in the `ArcAccessibility` component.