### PR TITLE
chore(workspcae): update playground docs context and add link to jira board for internal arup members

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,6 +138,8 @@ Or start the storybook development server with:
 npx nx run components:storybook:serve
 ```
 
+Source code chanages will be hot reloaded in the browser making any of the above commands ideal for local component development.
+
 ### Unit Tests
 
 Unit tests must be written for all components and can be run using the following command:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > Arup Reusable Components
 
-[Storybook](https://arc.arup.com) | [Documentation](#documentation) | [Playgrounds](#playgrounds) | [Sharepoint (Arup Internal)](https://arup.sharepoint.com/:u:/r/sites/ARCDesignSystem/SitePages/ARC-Design-System.aspx?csf=1&web=1&e=bkD3kw)
+[Storybook](https://arc.arup.com) | [Documentation](#documentation) | [Playgrounds](#playgrounds) | [Sharepoint (Arup Internal)](https://arup.sharepoint.com/:u:/r/sites/ARCDesignSystem/SitePages/ARC-Design-System.aspx?csf=1&web=1&e=bkD3kw) | [Jira (Arup Internal)](https://arupdigital.atlassian.net/jira/software/projects/ARC/boards/564)
 
 Thanks to the popularity of frameworks such as Angular, Vue, and React, component-driven development has become a part of our everyday lives. Components help us encapsulate styles and behaviours into reusable building blocks. They make a lot of sense in terms of design, development, and testing.
 


### PR DESCRIPTION
This adds some more context on how playgrounds can be used during local development and a link to the internal Arup ARC Jira board.