### PR TITLE
fix(components/container): listen to the arc-accessibility-open event on the bottom slotted element

### DIFF
--- a/packages/components/src/components/container/ArcContainer.ts
+++ b/packages/components/src/components/container/ArcContainer.ts
@@ -105,15 +105,10 @@ export default class ArcContainer extends LitElement {
     return html`
       ${when(this.banner, () => banner)}
       <div id="main">
-        <slot
-          id="nav"
-          name="nav"
-          @arc-show-accessibility=${this.showAccessibility}
-        >
-          <arc-navbar
-            @arc-show-accessibility=${this.showAccessibility}
-          ></arc-navbar>
+        <slot name="nav" @arc-show-accessibility=${this.showAccessibility}>
+          <arc-navbar @arc-show-accessibility=${this.showAccessibility} />
         </slot>
+
         <div
           id="container"
           class=${classMap({
@@ -126,6 +121,7 @@ export default class ArcContainer extends LitElement {
             <slot></slot>
           </div>
         </div>
+
         <slot
           name="accessibility"
           @arc-accessibility-change=${this.handleAccessibilityChange}
@@ -133,12 +129,11 @@ export default class ArcContainer extends LitElement {
           <arc-accessibility
             id="accessibility"
             @arc-accessibility-change=${this.handleAccessibilityChange}
-          ></arc-accessibility>
+          />
         </slot>
-        <slot name="bottom">
-          <arc-bottombar
-            @arc-show-accessibility=${this.showAccessibility}
-          ></arc-bottombar>
+
+        <slot name="bottom" @arc-show-accessibility=${this.showAccessibility}>
+          <arc-bottombar @arc-show-accessibility=${this.showAccessibility} />
         </slot>
       </div>
     `;


### PR DESCRIPTION
Adds an event listen for the `arc-accessibility-open` event for the element in the **bottom** slot of the `ArcContainer` component. The event listener opens the accessibility panel.

Fixes https://github.com/arup-group/arc-components/issues/297