### PR TITLE
fix(packages/components/container): fix dispatching an arc alert

### DIFF
--- a/packages/components/src/components/container/ArcContainer.ts
+++ b/packages/components/src/components/container/ArcContainer.ts
@@ -113,7 +113,9 @@ export default class ArcContainer extends LitElement {
   }
 
   /** @bata Open a notification. */
-  public dispatchNotification(config: NotificationConfiguration): ActionCallback {
+  public dispatchNotification(
+    config: NotificationConfiguration,
+  ): ActionCallback {
     if (isServer) return () => void 0;
 
     /* ensure that both the title and message have a minimum length */
@@ -151,6 +153,7 @@ export default class ArcContainer extends LitElement {
     if (!this.overlay) {
       const overlay = document.createElement('arc-overlay') as ArcOverlay;
       this.appendChild(overlay);
+      return overlay.dispatchAlert(config);
     }
 
     return this.overlay.dispatchAlert(config);

--- a/packages/components/src/components/container/ArcFlyer.ts
+++ b/packages/components/src/components/container/ArcFlyer.ts
@@ -190,7 +190,6 @@ export default class ArcFlyer extends LitElement {
         : this.prepend(notificationElement);
     }
 
-
     return closeCallback;
   }
   protected render() {


### PR DESCRIPTION
ensures an alert is dispatched by calling `ArcOverlay.dispatchAlert` on the newly created `ArcOverlay` element object.